### PR TITLE
Rework TH deriving instance context

### DIFF
--- a/tests/DataFamilies/Instances.hs
+++ b/tests/DataFamilies/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NoImplicitPrelude #-}


### PR DESCRIPTION
Instead of deriving instances for all datatype variables iterates over constructors generating instances based on how they are used. Does the right thing in cases like
*  Phantom type variables
  Does not add corresponding instance to the context
*  Type families
  Instead of generating `(ToJSON a)` for `data Foo a = Foo (SomeTypeFamily a)` generates `ToJSON (SomeTypeFamily a)`

TODO:
* [ ] How to test TH? Would be nice to make instance context directly SUT
* [ ] Which test cases to add?
* [ ] Both From and To?